### PR TITLE
Feat/#6 prejob sync/kan 285

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,9 @@ dependencies {
     // Swagger(Spring 3.x.x 이상부터 SpringFox 대신, SpringDoc)
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
 
+    // open feign
+    implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/myaong/popolog/prejobsservice/PrejobsServiceApplication.java
+++ b/src/main/java/myaong/popolog/prejobsservice/PrejobsServiceApplication.java
@@ -3,11 +3,13 @@ package myaong.popolog.prejobsservice;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
 @EnableDiscoveryClient
-@EnableJpaAuditing  
+@EnableJpaAuditing
+@EnableFeignClients
 public class PrejobsServiceApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/myaong/popolog/prejobsservice/feign/client/BlogServiceClient.java
+++ b/src/main/java/myaong/popolog/prejobsservice/feign/client/BlogServiceClient.java
@@ -1,0 +1,16 @@
+package myaong.popolog.prejobsservice.feign.client;
+
+import myaong.popolog.prejobsservice.feign.dto.request.PrejobsRequest;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+
+import java.util.List;
+
+@FeignClient(name = "blog-service")
+public interface BlogServiceClient {
+
+	@PostMapping("/blog/profiles/prejobs")
+	void createPrejobs(@RequestHeader(name = "memberId") Long memberId, @RequestBody List<PrejobsRequest> requests);
+}

--- a/src/main/java/myaong/popolog/prejobsservice/feign/dto/request/PrejobsRequest.java
+++ b/src/main/java/myaong/popolog/prejobsservice/feign/dto/request/PrejobsRequest.java
@@ -1,0 +1,14 @@
+package myaong.popolog.prejobsservice.feign.dto.request;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class PrejobsRequest {
+
+	Long memberPrejobId;
+	Long jobId;
+	String jobName;
+}
+

--- a/src/main/java/myaong/popolog/prejobsservice/feign/service/BlogService.java
+++ b/src/main/java/myaong/popolog/prejobsservice/feign/service/BlogService.java
@@ -1,0 +1,32 @@
+package myaong.popolog.prejobsservice.feign.service;
+
+import lombok.RequiredArgsConstructor;
+import myaong.popolog.prejobsservice.entity.PreferredJob;
+import myaong.popolog.prejobsservice.feign.client.BlogServiceClient;
+import myaong.popolog.prejobsservice.feign.dto.request.PrejobsRequest;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class BlogService {
+
+	private final BlogServiceClient blogServiceClient;
+
+	public void syncPrejobs(Long memberId, List<PreferredJob> prejobs) {
+
+		List<PrejobsRequest> requests = new ArrayList<>();
+		for (PreferredJob prejob : prejobs) {
+			PrejobsRequest request = PrejobsRequest.builder()
+					.memberPrejobId(prejob.getId())
+					.jobId(prejob.getJob().getId())
+					.jobName(prejob.getJob().getName())
+					.build();
+			requests.add(request);
+		}
+
+		blogServiceClient.createPrejobs(memberId, requests);
+	}
+}

--- a/src/main/java/myaong/popolog/prejobsservice/service/PrejobService.java
+++ b/src/main/java/myaong/popolog/prejobsservice/service/PrejobService.java
@@ -7,6 +7,7 @@ import myaong.popolog.prejobsservice.dto.request.PrejobRequest;
 import myaong.popolog.prejobsservice.dto.response.PrejobResponse;
 import myaong.popolog.prejobsservice.entity.Job;
 import myaong.popolog.prejobsservice.entity.PreferredJob;
+import myaong.popolog.prejobsservice.feign.service.BlogService;
 import myaong.popolog.prejobsservice.repository.JobRepository;
 import myaong.popolog.prejobsservice.repository.PreferredJobRepository;
 import org.springframework.stereotype.Service;
@@ -22,6 +23,7 @@ public class PrejobService {
 
     private final PreferredJobRepository preferredJobRepository;
     private final JobRepository jobRepository;
+    private final BlogService blogService;
 
     // 카테고리별 선택 가능한 직군 목록 조회
     @Transactional(readOnly = true)
@@ -73,7 +75,9 @@ public class PrejobService {
                         .build())
                 .collect(Collectors.toList());
 
-        preferredJobRepository.saveAll(newPreferredJobs);
+        List<PreferredJob> prejobs = preferredJobRepository.saveAll(newPreferredJobs);
+
+        blogService.syncPrejobs(memberId, prejobs);
     }
 
     // 특정 회원의 모든 관심 직군 삭제


### PR DESCRIPTION
## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치
develop

## 변경 사항
관심직군 등록/변경 시 블로그 서비스의 Prejob 엔티티와 동기화하는 기능을 추가했습니다.

## 이슈
- #6 

## 테스트 결과
![스크린샷 2024-12-18 034920](https://github.com/user-attachments/assets/e2be345f-bfcc-465c-ad96-6f47df2742f9)
- 요청 결과, DB의 member_prejob 테이블에도 변경사항이 적용된 것을 확인할 수 있습니다.
![스크린샷 2024-12-18 034951](https://github.com/user-attachments/assets/d4690e84-d401-4624-bd6f-e7605b524e16)